### PR TITLE
Rebuild smooth scroll

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,7 +20,6 @@
         "react-icons": "^4.2.0",
         "react-redux": "^7.2.2",
         "react-router-dom": "^5.2.0",
-        "react-router-hash-link": "^2.3.1",
         "react-scripts": "4.0.0",
         "redux": "^4.0.5",
         "redux-thunk": "^2.3.0",
@@ -14217,18 +14216,6 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "node_modules/react-router-hash-link": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.3.1.tgz",
-      "integrity": "sha512-QVYLaBLmRGovSbQv4Tbjqnl9JMEQ8c5rWebkZU16ovgZtpmNIf2znGj3uWaKkAL7lhuYBPcC3OAfhw7lk/QwNw==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=15",
-        "react-router-dom": ">=4"
       }
     },
     "node_modules/react-router/node_modules/isarray": {
@@ -31086,14 +31073,6 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-router-hash-link": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.3.1.tgz",
-      "integrity": "sha512-QVYLaBLmRGovSbQv4Tbjqnl9JMEQ8c5rWebkZU16ovgZtpmNIf2znGj3uWaKkAL7lhuYBPcC3OAfhw7lk/QwNw==",
-      "requires": {
-        "prop-types": "^15.7.2"
       }
     },
     "react-scripts": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,7 +15,6 @@
     "react-icons": "^4.2.0",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
-    "react-router-hash-link": "^2.3.1",
     "react-scripts": "4.0.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",

--- a/webapp/src/components/EventSummary/OnHome.js
+++ b/webapp/src/components/EventSummary/OnHome.js
@@ -1,5 +1,5 @@
-import { useDispatch } from 'react-redux';
-import { NavHashLink } from 'react-router-hash-link';
+import { useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { SetEnumerable, UnloadReel } from '../../store/reel';
 import { Focus, UnloadMap } from '../../store/map';
@@ -7,8 +7,12 @@ import SummaryBody from './SummaryBody';
 
 export default function OnHome ({ event }) {
   const dispatch = useDispatch();
+  const reelRef = useSelector(state => state.reel.ref);
+  const summaryHolder = useRef(null);
 
   const clickHandle = () => {
+    const top = summaryHolder.current.offsetTop;
+    reelRef.scrollTo({ top, behavior: 'smooth' });
     document.querySelectorAll('.map-pin')
       .forEach(pin => pin.classList.remove('focus'));
     document.getElementById(`map-pin-event-${event.id}`)
@@ -23,20 +27,16 @@ export default function OnHome ({ event }) {
   };
 
   return (
-    <NavHashLink
-      to={`#event-summary-${event.id}`}
-      smooth
+    <div
+      id={`event-summary-${event.id}`}
+      className='event-summary-container'
+      onClick={clickHandle}
+      ref={summaryHolder}
     >
-      <div
-        id={`event-summary-${event.id}`}
-        className='event-summary-container'
-        onClick={clickHandle}
-      >
-        <SummaryBody
-          event={event}
-          profileClick={profileClick}
-        />
-      </div>
-    </NavHashLink>
+      <SummaryBody
+        event={event}
+        profileClick={profileClick}
+      />
+    </div>
   );
 }

--- a/webapp/src/components/Home/EventReel.js
+++ b/webapp/src/components/Home/EventReel.js
@@ -1,8 +1,21 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
 import EventSummary from '../EventSummary';
+import { SetRef } from '../../store/reel';
 
 export default function EventReel ({ list }) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const hangingContainer = document.querySelector('div.event-reel-container');
+    hangingContainer && dispatch(SetRef(hangingContainer));
+  }, [dispatch]);
+
   return (
-    <div className='event-reel-container'>
+    <div
+      className='event-reel-container'
+    >
       {list.length
         ? list.map((event, idx) => (
           <EventSummary

--- a/webapp/src/components/Map/Pin.js
+++ b/webapp/src/components/Map/Pin.js
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { NavHashLink } from 'react-router-hash-link';
+import { useDispatch, useSelector } from 'react-redux';
 
 import DeepEqual from '../../utils/DeepEqual';
 import { Focus } from '../../store/map';
@@ -8,9 +7,12 @@ import { SetEnumerable } from '../../store/reel';
 
 export default function Pin ({ event }) {
   const dispatch = useDispatch();
+  const reelRef = useSelector(state => state.reel.ref);
   const [mouseXY, setMouseXY] = useState({ x: 0, y: 0 });
 
   const pinClick = () => {
+    const top = document.getElementById(`event-summary-${event.id}`).offsetTop;
+    reelRef.scrollTo({ top, behavior: 'smooth' });
     dispatch(SetEnumerable(false));
     document.querySelectorAll('.map-pin')
       .forEach(pin => pin.classList.remove('focus'));
@@ -19,27 +21,22 @@ export default function Pin ({ event }) {
   };
 
   return (
-    <NavHashLink
-      to={`#event-summary-${event.id}`}
-      smooth
-    >
-      <div className='map-pin-container'>
-        <div className='map-pin-precise' />
-        <div
-          className='map-pin'
-          id={`map-pin-event-${event.id}`}
-          onMouseDown={e => {
-            setMouseXY({ x: e.clientX, y: e.clientY });
-          }}
-          onMouseUp={e => {
-            (DeepEqual({ x: e.clientX, y: e.clientY }, mouseXY)) && pinClick();
-          }}
-        >
-          <div>
-            {event.title.toTitleCase()} with {event.Host.firstName}
-          </div>
+    <div className='map-pin-container'>
+      <div className='map-pin-precise' />
+      <div
+        className='map-pin'
+        id={`map-pin-event-${event.id}`}
+        onMouseDown={e => {
+          setMouseXY({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseUp={e => {
+          (DeepEqual({ x: e.clientX, y: e.clientY }, mouseXY)) && pinClick();
+        }}
+      >
+        <div>
+          {event.title.toTitleCase()} with {event.Host.firstName}
         </div>
       </div>
-    </NavHashLink>
+    </div>
   );
 }

--- a/webapp/src/store/reel.js
+++ b/webapp/src/store/reel.js
@@ -10,6 +10,8 @@ const LOAD = 'reel/LOAD';
 
 const UNLOAD = 'reel/UNLOAD';
 
+const REF = 'reel/REF';
+
 const enumerate = list => ({ type: ENUMERATE, list });
 
 export const HardSetList = pin => ({ type: ENUMERATE, list: pin ?? [] });
@@ -21,6 +23,8 @@ export const SetEnumerable = enumerable => ({ type: MODE, enumerable });
 export const LoadReel = () => ({ type: LOAD });
 
 export const UnloadReel = () => ({ type: UNLOAD });
+
+export const SetRef = ref => ({ type: REF, ref });
 
 export const EnumerateReel = (
   centerLng, centerLat, lowerLng,
@@ -49,8 +53,9 @@ const reducer = (state = {
   loaded: false,
   searchCenter: { lat: 0, lng: 0 },
   enumerable: true,
+  ref: null,
   store: []
-}, { type, list, enumerable }) => {
+}, { type, list, enumerable, ref }) => {
   switch (type) {
     case ENUMERATE:
       return {
@@ -70,6 +75,8 @@ const reducer = (state = {
         store: [],
         list: [...state.store]
       };
+    case REF:
+      return { ...state, ref };
     default:
       return state;
   }


### PR DESCRIPTION
Manually implement smooth scroll, simultaneously eliminating dependency on react-router-hash-link and eliminating invalid DOM nesting (a descendent of a)